### PR TITLE
npm audit fix

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -5768,20 +5768,12 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        }
+        "minimist": "^1.2.5"
       }
     },
     "ms": {

--- a/web/package.json
+++ b/web/package.json
@@ -1,12 +1,15 @@
 {
   "name": "lower-off",
   "version": "0.0.1",
-  "repository": {
-    "type" : "git",
-    "url" : "https://github.com/sparksp/lower-off.git",
-    "directory": "web"
-  },
   "description": "Random Sport Lower-off Scenarios",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sparksp/lower-off.git"
+  },
+  "bugs": {
+    "url": "https://github.com/sparksp/lower-off/issues"
+  },
+  "homepage": "https://github.com/sparksp/lower-off#readme",
   "main": "index.js",
   "scripts": {
     "build": "parcel build entry.html --out-file index.html",


### PR DESCRIPTION
Attempting to resolve https://www.npmjs.com/advisories/1179, however [minimist](https://github.com/substack/minimist) is being held back by [parcel](https://github.com/parcel-bundler/parcel) and [elm-analyse](https://github.com/stil4m/elm-analyse).