### PR TITLE
Fail when elm-tailwind-modules needs updating

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -114,4 +114,7 @@ jobs:
         run: echo "changed=$(git status --porcelain | wc -l)" >> $GITHUB_OUTPUT
       - name: Report changes
         if: steps.changes.outputs.changed == 1
-        run: echo "::error::Unstaged changes detected - it is likely that web/api.md5 need updating."
+        run: |
+          echo "::error::Unstaged changes detected - it is likely that the Elm Tailwind Modules need updating."
+          git status --porcelain
+          exit 1


### PR DESCRIPTION
This will cause the 'elm-tailwind-modules' workflow to fail if the modules are out of date, and will show git status in the logs.