### PR TITLE
Replace list-extra with core-extra

### DIFF
--- a/web/elm.json
+++ b/web/elm.json
@@ -14,7 +14,7 @@
             "elm/random": "1.0.0",
             "elm/url": "1.0.0",
             "elm-community/json-extra": "4.3.0",
-            "elm-community/list-extra": "8.6.0",
+            "elmcraft/core-extra": "2.0.0",
             "matheus23/elm-tailwind-modules-base": "1.0.0",
             "rtfeldman/elm-css": "18.0.0"
         },
@@ -23,6 +23,7 @@
             "elm/file": "1.0.5",
             "elm/html": "1.0.0",
             "elm/parser": "1.1.0",
+            "elm/regex": "1.0.0",
             "elm/time": "1.0.0",
             "elm/virtual-dom": "1.0.2",
             "robinheghan/murmur3": "1.0.0",


### PR DESCRIPTION
Use [elmcraft/core-extra](https://github.com/elmcraft/core-extra/) instead of elm-community/list-extra.

Note: elm-community/json-extra is not covered in core-extra.